### PR TITLE
Explore ModernBERT French encoder

### DIFF
--- a/modernbert_french_implementation.py
+++ b/modernbert_french_implementation.py
@@ -1,0 +1,378 @@
+"""
+ModernBERT French Implementation Guide
+=====================================
+
+This module provides practical examples for experimenting with ModernBERT
+for French NLP tasks, including fine-tuning strategies and hybrid approaches.
+"""
+
+import torch
+from transformers import (
+    AutoTokenizer, 
+    AutoModel, 
+    AutoModelForMaskedLM,
+    AutoModelForSequenceClassification,
+    CamembertTokenizer, 
+    CamembertModel,
+    TrainingArguments,
+    Trainer
+)
+from datasets import Dataset
+import numpy as np
+from typing import List, Dict, Tuple
+import logging
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+
+class ModernBERTFrenchAdapter:
+    """
+    Adapter class for using ModernBERT with French text.
+    Provides various strategies for leveraging ModernBERT's advantages.
+    """
+    
+    def __init__(self, strategy: str = "fine-tune"):
+        """
+        Initialize the adapter with a specific strategy.
+        
+        Args:
+            strategy: One of ["fine-tune", "zero-shot", "hybrid"]
+        """
+        self.strategy = strategy
+        self.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+        
+    def load_modernbert_for_finetuning(self):
+        """Load ModernBERT model for fine-tuning on French data."""
+        logger.info("Loading ModernBERT for fine-tuning...")
+        
+        # Load English ModernBERT
+        self.tokenizer = AutoTokenizer.from_pretrained("answerdotai/ModernBERT-base")
+        self.model = AutoModelForMaskedLM.from_pretrained(
+            "answerdotai/ModernBERT-base",
+            torch_dtype=torch.float16 if torch.cuda.is_available() else torch.float32
+        ).to(self.device)
+        
+        return self.model, self.tokenizer
+    
+    def prepare_french_data(self, texts: List[str], max_length: int = 8192):
+        """
+        Prepare French text data for ModernBERT processing.
+        
+        Args:
+            texts: List of French text strings
+            max_length: Maximum sequence length (up to 8192 for ModernBERT)
+        """
+        # Tokenize with ModernBERT tokenizer
+        encoded = self.tokenizer(
+            texts,
+            max_length=max_length,
+            truncation=True,
+            padding=True,
+            return_tensors="pt"
+        )
+        
+        logger.info(f"Tokenized {len(texts)} texts with max length {max_length}")
+        return encoded
+    
+    def create_mlm_dataset(self, texts: List[str], mlm_probability: float = 0.30):
+        """
+        Create masked language modeling dataset for French fine-tuning.
+        ModernBERT uses 30% masking rate instead of BERT's 15%.
+        """
+        def mask_tokens(inputs):
+            labels = inputs["input_ids"].clone()
+            
+            # Create probability matrix for masking
+            probability_matrix = torch.full(labels.shape, mlm_probability)
+            
+            # Don't mask special tokens
+            special_tokens_mask = [
+                self.tokenizer.get_special_tokens_mask(val, already_has_special_tokens=True) 
+                for val in labels.tolist()
+            ]
+            probability_matrix.masked_fill_(
+                torch.tensor(special_tokens_mask, dtype=torch.bool), 
+                value=0.0
+            )
+            
+            # Mask tokens
+            masked_indices = torch.bernoulli(probability_matrix).bool()
+            labels[~masked_indices] = -100  # Only compute loss on masked tokens
+            
+            # Replace masked tokens
+            inputs["input_ids"][masked_indices] = self.tokenizer.mask_token_id
+            inputs["labels"] = labels
+            
+            return inputs
+        
+        # Tokenize texts
+        encoded = self.prepare_french_data(texts)
+        
+        # Apply masking
+        dataset = []
+        for i in range(len(texts)):
+            item = {
+                "input_ids": encoded["input_ids"][i],
+                "attention_mask": encoded["attention_mask"][i]
+            }
+            masked_item = mask_tokens(item)
+            dataset.append(masked_item)
+        
+        return Dataset.from_list(dataset)
+
+
+class HybridFrenchEncoder:
+    """
+    Hybrid approach combining CamemBERT's French expertise 
+    with ModernBERT's architectural advantages.
+    """
+    
+    def __init__(self):
+        self.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+        
+        # Load both models
+        self.camembert_tokenizer = CamembertTokenizer.from_pretrained("camembert/camembert-base")
+        self.camembert_model = CamembertModel.from_pretrained("camembert/camembert-base").to(self.device)
+        
+        self.modernbert_tokenizer = AutoTokenizer.from_pretrained("answerdotai/ModernBERT-base")
+        self.modernbert_model = AutoModel.from_pretrained("answerdotai/ModernBERT-base").to(self.device)
+        
+    def encode_short_french(self, text: str):
+        """Use CamemBERT for short French texts (< 512 tokens)."""
+        inputs = self.camembert_tokenizer(
+            text, 
+            return_tensors="pt", 
+            max_length=512, 
+            truncation=True
+        ).to(self.device)
+        
+        with torch.no_grad():
+            outputs = self.camembert_model(**inputs)
+        
+        return outputs.last_hidden_state.mean(dim=1)  # Mean pooling
+    
+    def encode_long_mixed(self, text: str):
+        """
+        Use ModernBERT for long or code-mixed French texts.
+        Useful for technical documentation or code + French.
+        """
+        inputs = self.modernbert_tokenizer(
+            text, 
+            return_tensors="pt", 
+            max_length=8192, 
+            truncation=True
+        ).to(self.device)
+        
+        with torch.no_grad():
+            outputs = self.modernbert_model(**inputs)
+        
+        return outputs.last_hidden_state.mean(dim=1)  # Mean pooling
+    
+    def smart_encode(self, text: str):
+        """
+        Intelligently choose encoder based on text characteristics.
+        """
+        # Simple heuristic: use token count and code detection
+        token_count = len(self.camembert_tokenizer.tokenize(text))
+        has_code = any(marker in text for marker in ["```", "def ", "class ", "import "])
+        
+        if token_count > 400 or has_code:
+            logger.info("Using ModernBERT for long/technical text")
+            return self.encode_long_mixed(text)
+        else:
+            logger.info("Using CamemBERT for short French text")
+            return self.encode_short_french(text)
+
+
+class ModernBERTFrenchFineTuner:
+    """
+    Fine-tuning ModernBERT for French NLP tasks.
+    """
+    
+    def __init__(self, task: str = "classification"):
+        self.task = task
+        self.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+        
+    def prepare_for_classification(self, num_labels: int = 2):
+        """Prepare ModernBERT for French text classification."""
+        self.model = AutoModelForSequenceClassification.from_pretrained(
+            "answerdotai/ModernBERT-base",
+            num_labels=num_labels,
+            torch_dtype=torch.float16 if torch.cuda.is_available() else torch.float32
+        ).to(self.device)
+        
+        self.tokenizer = AutoTokenizer.from_pretrained("answerdotai/ModernBERT-base")
+        
+        return self.model, self.tokenizer
+    
+    def create_training_args(self, output_dir: str = "./modernbert-french"):
+        """Create optimized training arguments for ModernBERT."""
+        return TrainingArguments(
+            output_dir=output_dir,
+            num_train_epochs=3,
+            per_device_train_batch_size=8,  # Adjust based on GPU memory
+            per_device_eval_batch_size=16,
+            warmup_steps=500,
+            weight_decay=0.01,
+            logging_dir=f"{output_dir}/logs",
+            logging_steps=10,
+            evaluation_strategy="steps",
+            eval_steps=500,
+            save_strategy="steps",
+            save_steps=1000,
+            load_best_model_at_end=True,
+            metric_for_best_model="eval_loss",
+            greater_is_better=False,
+            fp16=torch.cuda.is_available(),  # Use mixed precision if available
+            gradient_checkpointing=True,  # Save memory for long sequences
+            dataloader_num_workers=4,
+        )
+
+
+def compare_models_example():
+    """
+    Example comparing CamemBERT and ModernBERT on French text.
+    """
+    # Sample French texts of different lengths
+    short_text = "Paris est la capitale de la France."
+    long_text = """
+    L'intelligence artificielle transforme notre société. Les modèles de langage 
+    comme BERT ont révolutionné le traitement du langage naturel. Ces modèles 
+    peuvent comprendre le contexte et les nuances du langage humain...
+    """ * 50  # Repeat to make it long
+    
+    code_mixed_text = """
+    Voici un exemple de code Python:
+    ```python
+    def calculer_moyenne(nombres: List[float]) -> float:
+        '''Calcule la moyenne d'une liste de nombres.'''
+        return sum(nombres) / len(nombres)
+    ```
+    Cette fonction est très utile pour l'analyse statistique.
+    """
+    
+    # Initialize hybrid encoder
+    hybrid = HybridFrenchEncoder()
+    
+    # Test encodings
+    print("Testing short French text...")
+    short_encoding = hybrid.smart_encode(short_text)
+    print(f"Encoding shape: {short_encoding.shape}")
+    
+    print("\nTesting long French text...")
+    long_encoding = hybrid.smart_encode(long_text)
+    print(f"Encoding shape: {long_encoding.shape}")
+    
+    print("\nTesting code-mixed French text...")
+    code_encoding = hybrid.smart_encode(code_mixed_text)
+    print(f"Encoding shape: {code_encoding.shape}")
+
+
+def fine_tuning_example():
+    """
+    Example of fine-tuning ModernBERT on French data.
+    """
+    # Initialize fine-tuner
+    fine_tuner = ModernBERTFrenchFineTuner(task="classification")
+    model, tokenizer = fine_tuner.prepare_for_classification(num_labels=3)
+    
+    # Example French classification data
+    french_texts = [
+        "Ce film est absolument magnifique!",
+        "Je n'ai pas aimé ce livre.",
+        "Le service était correct, sans plus.",
+    ]
+    labels = [2, 0, 1]  # Positive, Negative, Neutral
+    
+    # Prepare dataset
+    def tokenize_function(examples):
+        return tokenizer(
+            examples["text"], 
+            padding="max_length", 
+            truncation=True,
+            max_length=512
+        )
+    
+    # Create dataset
+    dataset = Dataset.from_dict({
+        "text": french_texts,
+        "labels": labels
+    })
+    tokenized_dataset = dataset.map(tokenize_function, batched=True)
+    
+    # Create trainer
+    training_args = fine_tuner.create_training_args()
+    trainer = Trainer(
+        model=model,
+        args=training_args,
+        train_dataset=tokenized_dataset,
+        eval_dataset=tokenized_dataset,  # In practice, use separate validation set
+        tokenizer=tokenizer,
+    )
+    
+    # Fine-tune (commented out to avoid actual training in example)
+    # trainer.train()
+    
+    print("Fine-tuning setup complete!")
+
+
+def migration_path_example():
+    """
+    Example showing migration path from CamemBERT to ModernBERT.
+    """
+    class FrenchTextProcessor:
+        def __init__(self, use_modernbert: bool = False):
+            self.use_modernbert = use_modernbert
+            
+            if use_modernbert:
+                # Future: Use French ModernBERT when available
+                self.model_name = "answerdotai/ModernBERT-base-fr"  # Hypothetical
+                self.max_length = 8192
+            else:
+                # Current: Use CamemBERT
+                self.model_name = "camembert/camembert-base"
+                self.max_length = 512
+            
+            # Load model and tokenizer
+            self.tokenizer = AutoTokenizer.from_pretrained(self.model_name)
+            self.model = AutoModel.from_pretrained(self.model_name)
+        
+        def process(self, text: str):
+            """Process French text with appropriate model."""
+            inputs = self.tokenizer(
+                text,
+                return_tensors="pt",
+                max_length=self.max_length,
+                truncation=True,
+                padding=True
+            )
+            
+            with torch.no_grad():
+                outputs = self.model(**inputs)
+            
+            return outputs.last_hidden_state
+    
+    # Example usage
+    processor_current = FrenchTextProcessor(use_modernbert=False)
+    # processor_future = FrenchTextProcessor(use_modernbert=True)
+    
+    text = "Voici un exemple de texte en français."
+    result = processor_current.process(text)
+    print(f"Processed with {processor_current.model_name}: {result.shape}")
+
+
+if __name__ == "__main__":
+    print("ModernBERT French Implementation Examples")
+    print("=" * 50)
+    
+    print("\n1. Model Comparison Example:")
+    compare_models_example()
+    
+    print("\n2. Fine-tuning Setup Example:")
+    fine_tuning_example()
+    
+    print("\n3. Migration Path Example:")
+    migration_path_example()
+    
+    print("\nNote: ModernBERT-fr is hypothetical. Monitor HuggingFace for updates!")

--- a/modernbert_french_research.md
+++ b/modernbert_french_research.md
@@ -1,0 +1,275 @@
+# Implementing ModernBERT French Encoder Instead of CamemBERT: Exploration and Potential Benefits
+
+## Executive Summary
+
+This document explores the implementation of ModernBERT as a French language encoder to replace CamemBERT in NLP applications. While ModernBERT offers significant architectural and performance improvements, the current version is primarily English-focused, requiring either fine-tuning or waiting for a dedicated French version.
+
+## Introduction
+
+### Current State: CamemBERT
+- **Release**: 2019
+- **Architecture**: Based on RoBERTa (2019)
+- **Training**: 138GB of French text
+- **Context Length**: 512 tokens
+- **Parameters**: 110M (base)
+- **Monthly Downloads**: Millions on HuggingFace
+
+### ModernBERT Overview
+- **Release**: December 2024
+- **Architecture**: Modernized BERT with latest transformer improvements
+- **Training**: 2 trillion tokens
+- **Context Length**: 8,192 tokens (16x larger than CamemBERT)
+- **Parameters**: 149M (base), 395M (large)
+
+## Key Advantages of ModernBERT
+
+### 1. Extended Context Length
+- **ModernBERT**: 8,192 tokens
+- **CamemBERT**: 512 tokens
+- **Benefit**: Can process entire documents instead of small chunks, crucial for:
+  - Document-level understanding
+  - Full-article RAG systems
+  - Long-form content analysis
+
+### 2. Architectural Improvements
+
+#### Modern Attention Mechanism
+- **Alternating Attention**: Global attention every 3 layers, local attention (128 tokens) otherwise
+- **Benefit**: Dramatically faster processing of long sequences
+- **Impact**: 2-3x faster inference on long contexts
+
+#### Rotary Position Embeddings (RoPE)
+- Better positional understanding
+- Enables longer sequence processing
+- More stable for extended contexts
+
+#### GeGLU Activation
+- Replaces traditional GeLU
+- Improved gradient flow
+- Better performance
+
+#### Unpadding and Sequence Packing
+- Eliminates wasted computation on padding tokens
+- 10-20% speedup in processing
+- More efficient batch processing
+
+### 3. Performance Improvements
+- **Speed**: 2x faster than DeBERTa, 4x faster on variable-length inputs
+- **Memory**: Uses 1/5th of DeBERTa's memory
+- **Efficiency**: Optimized for consumer GPUs (RTX 4090, etc.)
+
+### 4. Training Data Diversity
+- Includes code, scientific articles, web documents
+- More diverse than CamemBERT's Wikipedia/book focus
+- Better generalization potential
+
+## Implementation Challenges for French
+
+### 1. Language Barrier
+**Current Status**: ModernBERT is trained on English data
+**Challenge**: Direct use would require:
+- Multilingual tokenizer adaptation
+- Cross-lingual transfer learning
+- Potential performance degradation
+
+### 2. Available Options
+
+#### Option A: Fine-tune English ModernBERT
+```python
+from transformers import AutoTokenizer, AutoModelForMaskedLM
+
+# Load English ModernBERT
+model = AutoModelForMaskedLM.from_pretrained("answerdotai/ModernBERT-base")
+tokenizer = AutoTokenizer.from_pretrained("answerdotai/ModernBERT-base")
+
+# Fine-tune on French data
+# Requires substantial French corpus and compute
+```
+
+**Pros**:
+- Leverages architectural improvements
+- Can start immediately
+- Preserves efficiency gains
+
+**Cons**:
+- Suboptimal tokenization for French
+- Requires significant compute
+- May not reach CamemBERT's French performance
+
+#### Option B: Wait for French ModernBERT
+Based on the arxiv paper (arXiv:2504.08716), researchers are already comparing ModernBERT with CamemBERTaV2 (DeBERTaV3 French model).
+
+**Expected Timeline**: Unknown, but likely 2025
+**Potential Names**: ModernBERT-fr, ModernCamemBERT
+
+#### Option C: Multilingual Approach
+Use existing multilingual models as a bridge:
+- mBERT (includes French)
+- XLM-RoBERTa
+
+Then apply ModernBERT's architectural improvements.
+
+### 3. Technical Considerations
+
+#### Tokenization
+- ModernBERT uses different tokenizer than CamemBERT
+- French-specific tokens may be poorly represented
+- Would need vocabulary expansion or replacement
+
+#### Compute Requirements
+- Full pretraining: ~$60,000 in compute (based on FineWeb-Edu example)
+- Fine-tuning: Significantly less, but still substantial
+
+## Comparative Analysis
+
+| Feature | CamemBERT | ModernBERT (English) | Potential French ModernBERT |
+|---------|-----------|---------------------|---------------------------|
+| **Max Sequence Length** | 512 | 8,192 | 8,192 |
+| **Architecture** | RoBERTa (2019) | Modern Transformer++ | Modern Transformer++ |
+| **French Performance** | Excellent | Poor (not trained) | Expected: Excellent |
+| **Speed** | Baseline | 2-4x faster | 2-4x faster |
+| **Memory Efficiency** | Baseline | 5x better | 5x better |
+| **Code Understanding** | Limited | Excellent | Depends on training |
+
+## Implementation Strategy
+
+### Short-term (Immediate)
+1. **Continue using CamemBERT** for production
+2. **Experiment with ModernBERT** fine-tuning on French data
+3. **Benchmark** performance vs. CamemBERT
+
+### Medium-term (3-6 months)
+1. **Monitor** French ModernBERT developments
+2. **Prepare** French training corpus
+3. **Design** migration strategy
+
+### Long-term (6-12 months)
+1. **Adopt** French ModernBERT when available
+2. **Migrate** existing systems
+3. **Leverage** long-context capabilities
+
+## Code Migration Example
+
+### Current CamemBERT Implementation
+```python
+from transformers import CamembertTokenizer, CamembertModel
+
+tokenizer = CamembertTokenizer.from_pretrained("camembert/camembert-base")
+model = CamembertModel.from_pretrained("camembert/camembert-base")
+
+# Max 512 tokens
+text = "Votre texte en français"
+inputs = tokenizer(text, max_length=512, truncation=True, return_tensors="pt")
+outputs = model(**inputs)
+```
+
+### Future ModernBERT French Implementation
+```python
+from transformers import AutoTokenizer, AutoModel
+
+# Hypothetical French ModernBERT
+tokenizer = AutoTokenizer.from_pretrained("answerdotai/ModernBERT-base-fr")
+model = AutoModel.from_pretrained("answerdotai/ModernBERT-base-fr")
+
+# Up to 8192 tokens!
+text = "Votre très long texte en français..."
+inputs = tokenizer(text, max_length=8192, truncation=True, return_tensors="pt")
+outputs = model(**inputs)
+```
+
+## Potential Benefits for French NLP
+
+### 1. Document-Level Understanding
+- Process entire legal documents
+- Full news articles analysis
+- Complete scientific papers
+
+### 2. Improved RAG Systems
+- Larger context chunks
+- Better semantic coherence
+- Reduced chunking artifacts
+
+### 3. Code-Mixed Content
+- French technical documentation
+- Programming tutorials in French
+- Mixed code/text analysis
+
+### 4. Efficiency Gains
+- Faster processing
+- Lower infrastructure costs
+- Better scalability
+
+## Risks and Mitigation
+
+### Risk 1: Performance Regression
+**Mitigation**: Extensive benchmarking before migration
+
+### Risk 2: Compatibility Issues
+**Mitigation**: Gradual migration with fallback options
+
+### Risk 3: Training Costs
+**Mitigation**: Collaborate with French NLP community
+
+## Recommendations
+
+### 1. Immediate Actions
+- Set up ModernBERT English for experimentation
+- Create French evaluation benchmarks
+- Monitor ModernBERT developments
+
+### 2. Preparation Steps
+- Collect diverse French training data
+- Design compatibility layer for existing systems
+- Allocate budget for potential fine-tuning
+
+### 3. Community Engagement
+- Connect with ModernBERT team about French plans
+- Collaborate with French NLP researchers
+- Consider joint training efforts
+
+## Conclusion
+
+ModernBERT represents a significant advancement in encoder architecture, offering:
+- 16x longer context (8,192 vs 512 tokens)
+- 2-4x faster processing
+- 5x better memory efficiency
+- Modern architectural improvements
+
+While immediate French support is limited, the potential benefits justify:
+1. Monitoring developments closely
+2. Preparing for migration
+3. Experimenting with fine-tuning approaches
+
+The French NLP community would greatly benefit from a dedicated French ModernBERT model, combining CamemBERT's linguistic excellence with ModernBERT's architectural superiority.
+
+## References
+
+1. Martin et al. (2020). CamemBERT: a Tasty French Language Model. ACL 2020.
+2. Warner et al. (2024). Smarter, Better, Faster, Longer: A Modern Bidirectional Encoder. arXiv:2412.13663
+3. Antoun et al. (2025). ModernBERT or DeBERTaV3? Examining Architecture and Data Influence. arXiv:2504.08716
+4. Antoun et al. (2024). CamemBERT 2.0: A Smarter French Language Model Aged to Perfection. arXiv:2411.08868
+
+## Appendix: Technical Specifications
+
+### CamemBERT Specifications
+```yaml
+model_type: roberta
+hidden_size: 768
+num_hidden_layers: 12
+num_attention_heads: 12
+max_position_embeddings: 514
+vocab_size: 32005
+type_vocab_size: 1
+```
+
+### ModernBERT Specifications
+```yaml
+model_type: modernbert
+hidden_size: 768 (base) / 1024 (large)
+num_hidden_layers: 22 (base) / 28 (large)
+num_attention_heads: 12 (base) / 16 (large)
+max_position_embeddings: 8192
+vocab_size: 50368
+global_attn_every_n_layers: 3
+local_attention_window: 128
+```


### PR DESCRIPTION
Add research and implementation guidance for using ModernBERT as a French encoder instead of CamemBERT.